### PR TITLE
Increased Rm2Pro Rf learning stability

### DIFF
--- a/ConsoleTest/ConsoleTest.csproj
+++ b/ConsoleTest/ConsoleTest.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xb.Core" Version="1.0.13" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\SharpBroadlink\SharpBroadlink.csproj" />
   </ItemGroup>
 

--- a/ConsoleTest/Program.cs
+++ b/ConsoleTest/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -111,13 +112,21 @@ namespace ConsoleTest
             byte[] command = null;
             try
             {
-                Action<string> moveToStage2 = (txt) =>
+                Action<Rm2Pro.RfLearningSteps> learnInstructionHandler = (instructions) =>
                 {
-                    Console.WriteLine(txt);
+                    //Get description from the enum - any other text will do
+                    var msg = instructions.GetType().GetField(instructions.ToString())
+                        ?.GetCustomAttributes(typeof(DescriptionAttribute), true)
+                        .OfType<DescriptionAttribute>()
+                        .FirstOrDefault()
+                        ?.Description
+                        ?? instructions.ToString();
+                        
+                    Console.WriteLine(msg);
                     Console.ReadKey(true);
                 };
 
-                command = await rm.LearnRfCommand(moveToStage2, cancellationSource.Token, () =>
+                command = await rm.LearnRfCommand(learnInstructionHandler, cancellationSource.Token, () =>
                 {
                     Console.Write('.');
                 });

--- a/ConsoleTest/Program.cs
+++ b/ConsoleTest/Program.cs
@@ -112,7 +112,7 @@ namespace ConsoleTest
             byte[] command = null;
             try
             {
-                Action<Rm2Pro.RfLearningSteps> learnInstructionHandler = (instructions) =>
+                Action<Rm2Pro.LearnInstructions> learnInstructionHandler = (instructions) =>
                 {
                     //Get description from the enum - any other text will do
                     var msg = instructions.GetType().GetField(instructions.ToString())

--- a/SharpBroadlink/Devices/LearnInstructions.cs
+++ b/SharpBroadlink/Devices/LearnInstructions.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel;
+
+namespace SharpBroadlink.Devices
+{
+    public enum LearnInstructions
+    {
+        [Description("Press and hold the remote button")]
+        PressAndHoldRemotedButton,
+        [Description("Release the remote button")]
+        ReleaseRemoteButton,
+        [Description("Press shortly the remote button you want to learn")]
+        PressRemoteButtonShortly,
+    }
+}

--- a/SharpBroadlink/Devices/Rm.cs
+++ b/SharpBroadlink/Devices/Rm.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -139,8 +138,8 @@ namespace SharpBroadlink.Devices
         /// <returns>IR command</returns>
         /// <exception cref="InvalidOperationException">In case of failure</exception>
         /// <exception cref="TaskCanceledException">In case learning has benn cancelled</exception>
-        public Task<byte[]> LearnIRCommnad(CancellationToken cancellationToken)
-        {            
+        public Task<byte[]> LearnIRCommnad(Action<LearnInstructions> learnInstructions, CancellationToken cancellationToken)
+        {
             return Task.Run(async () =>
             {
                 try
@@ -152,9 +151,11 @@ namespace SharpBroadlink.Devices
                         throw new InvalidOperationException("Failed to enter IR learning");
 
                     cancellationToken.ThrowIfCancellationRequested();
+                    learnInstructions?.Invoke(LearnInstructions.PressRemoteButtonShortly);
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     byte[] command = null;
-                    while(null == (command = await CheckData()))
+                    while (null == (command = await CheckData()))
                     {
                         cancellationToken.ThrowIfCancellationRequested();
                         await Task.Delay(IRLearnIterval);

--- a/SharpBroadlink/Devices/Rm2Pro.cs
+++ b/SharpBroadlink/Devices/Rm2Pro.cs
@@ -15,8 +15,8 @@ namespace SharpBroadlink.Devices
     {
         #region Properties
 
-        public static TimeSpan RfFrequencyLearnInterval { get; set; } = TimeSpan.FromMilliseconds(100);
-        public static TimeSpan RfCommandLearnInterval { get; set; } = TimeSpan.FromMilliseconds(100);
+        public static TimeSpan RfFrequencyLearnInterval { get; set; } = TimeSpan.FromMilliseconds(1000);
+        public static TimeSpan RfCommandLearnInterval { get; set; } = TimeSpan.FromMilliseconds(1000);
 
         #endregion Properties
 
@@ -38,10 +38,66 @@ namespace SharpBroadlink.Devices
         #region Public Methods
 
         /// <summary>
+        /// Async method for learning RF commands
+        /// </summary>
+        /// <remarks>User should press and hold remote button until learning is finished</remarks>
+        /// <param name="learnInstructions">When this action is invoked, instructions should be show to the user</param>
+        /// <param name="cancellationToken">Used to cancel RF learning</param>
+        /// <returns>Learned RF command</returns>
+        /// <exception cref="InvalidOperationException">In case of failure</exception>
+        /// <exception cref="TaskCanceledException">In case learning has benn cancelled</exception>
+        public async Task<byte[]> LearnRfCommand(Action<string> learnInstructions, CancellationToken cancellationToken, Action learnProgress = null)
+        {            
+            return await Task.Run(async () =>
+            {
+                try
+                {
+                    if (!await CancelLearning())
+                        throw new InvalidOperationException("Failed to cancel any previous learning");
+                    learnInstructions?.Invoke("Press and hold the remote button");
+
+                    if (!await SweepFrequencies())
+                        throw new InvalidOperationException("Failed to sweep frequencies");
+
+                    //Learn RF frequency - remote should be held all the time
+                    while (!await LearnRfFrequency())
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        learnProgress?.Invoke();
+                        await Task.Delay(RfFrequencyLearnInterval, cancellationToken);
+                    }
+
+                    learnInstructions?.Invoke("Release the remote");
+
+                    //Move to step 2 - learning the actual command
+                    await FindRfPacket();
+                    learnInstructions?.Invoke("Press again shortly the button you want to learn");
+
+                    byte[] commandData = null;
+                    while(null == (commandData = await CheckData()))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        learnProgress?.Invoke();
+                        await Task.Delay(RfCommandLearnInterval, cancellationToken);
+                    }
+                    return commandData;
+                }
+                finally
+                {
+                    await CancelLearning();
+                }
+            }, cancellationToken);
+        }
+
+        #endregion Public Methods
+
+        #region Private Methods
+
+        /// <summary>
         /// Switch into RF Learning mode
         /// </summary>
         /// <returns></returns>
-        public async Task<bool> SweepFrequencies()
+        private async Task<bool> SweepFrequencies()
         {
             var packet = new byte[16];
             packet[0] = 0x19;
@@ -55,7 +111,7 @@ namespace SharpBroadlink.Devices
         /// Enter RF frequency learning
         /// </summary>
         /// <returns>True if entering learning was successful</returns>
-        public async Task<bool> LearnRfFrequency()
+        private async Task<bool> LearnRfFrequency()
         {
             var packet = new byte[16];
             packet[0] = 0x1a;
@@ -80,105 +136,25 @@ namespace SharpBroadlink.Devices
         }
 
         /// <summary>
-        /// Cancel RF Learning mode
+        /// Starts RF packet discovery
         /// </summary>
-        /// <returns>True if the succedded, false otherwise</returns>
-        public async Task<bool> CancelRfLearning()
-        {
-            return await CancelLearning();
-        }
-
-        /// <summary>
-        /// [Pilot Implementation] Send RF signal-data
-        /// </summary>
-        /// <param name="data"></param>
-        /// <returns></returns>
-        /// <remarks>
-        /// ** Warning **
-        /// This is a pilot implementation.
-        /// Learning of RF signal does NOT WORKS.
-        /// 
-        /// I have not done it.
-        /// Because signal data could not be acquired.
-        /// </remarks>
-        public async Task<bool> SendRfData(byte[] data)
-        {
-            var packet = new List<byte>() { 0x02, 0x00, 0x00, 0x00 };
-            packet.AddRange(data);
-
-            await SendPacket(0x6a, packet.ToArray());
-
-            return true;
-        }
-
-        /// <summary>
-        /// Async method for learning RF commands
-        /// </summary>
-        /// <remarks>User should press and hold remote button until learning is finished</remarks>
-        /// <param name="cancellationToken">Used to cancel RF learning</param>
-        /// <returns>Learned RF command</returns>
-        /// <exception cref="InvalidOperationException">In case of failure</exception>
-        /// <exception cref="TaskCanceledException">In case learning has benn cancelled</exception>
-        public async Task<byte[]> LearnRfCommand(CancellationToken cancellationToken, Action learnProgress = null)
-        {            
-            return await Task.Run(async () =>
-            {
-                try
-                {
-                    if (!await CancelRfLearning())
-                        throw new InvalidOperationException("Failed to cancel any previous learning");
-
-                    if (!await SweepFrequencies())
-                        throw new InvalidOperationException("Failed to sweep frequencies");
-
-                    //Learn RF frequency - remote should be held all the time
-                    while (!await LearnRfFrequency())
-                    {
-                        learnProgress?.Invoke();
-                        cancellationToken.ThrowIfCancellationRequested();
-                        await Task.Delay(RfFrequencyLearnInterval, cancellationToken);
-                    }
-
-                    //Move to step 2 - learning the actual command
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    byte[] commandData = null;
-                    while(null == (commandData = await CheckData()))
-                    {
-                        learnProgress?.Invoke();
-                        cancellationToken.ThrowIfCancellationRequested();
-                        await Task.Delay(RfCommandLearnInterval, cancellationToken);
-                    }
-                    return commandData;
-                }
-                finally
-                {
-                    await CancelRfLearning();
-                }
-            }, cancellationToken);
-        }
-
-        #endregion Public Methods
-
-        #region Private Methods
-
-        /// <summary>
-        /// This doesn't seem to be required for RF learning at all. I'm leaving it because of phyton lib campatibility
-        /// </summary>
-        /// <returns></returns>
-        private async Task<bool> find_rf_packet()
+        /// <remarks>Return value doesn't seem to be correct, it's always incorrect</remarks>
+        /// <returns>Ignore?</returns>
+        private async Task<bool> FindRfPacket()
         {
             var packet = new byte[16];
             packet[0] = 0x1b;
 
             var response = await SendPacket(0x6a, packet);
-            if (response == null || response.Length <= 0x38)
+            if (response == null || response.Length <= 0x39)
                 return false;
 
             var err = response[0x22] | (response[0x23] << 8);
             if (err == 0)
             {
                 var payload = Decrypt(response, 0x38);
+                if (payload.Length < 5)
+                    return false;
                 return payload[0x04] == 1;
             }
 

--- a/SharpBroadlink/SharpBroadlink.csproj
+++ b/SharpBroadlink/SharpBroadlink.csproj
@@ -18,7 +18,6 @@ This is a port of python-broadlink to C# .Net Standard.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xb.Core" Version="1.0.13" />
     <PackageReference Include="Xb.Net" Version="1.0.6" />
   </ItemGroup>
 

--- a/SharpBroadlink/SharpBroadlink.csproj
+++ b/SharpBroadlink/SharpBroadlink.csproj
@@ -15,6 +15,7 @@ This is a port of python-broadlink to C# .Net Standard.</Description>
     <NeutralLanguage>ja</NeutralLanguage>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>1.0.2.0</AssemblyVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Previous push was Proof of Concept for RF learning capabilities. But it wasn't stable. Sometimes the learning procedure wasn't successful, sometimes next learning attempts were failing.
This push should fix those issues. Tested in production environment.
Also, reduced memory garbage production and unified the api to a simple, disposable, awaitabe API.